### PR TITLE
Correction to the modHexConversion table

### DIFF
--- a/src/Yubico/Response.ts
+++ b/src/Yubico/Response.ts
@@ -211,12 +211,11 @@ export class Response {
             j: "8",
             k: "9",
             l: "A",
-            m: "B",
-            n: "C",
-            r: "D",
-            t: "E",
-            u: "F",
-            v: "G",
+            n: "B",
+            r: "C",
+            t: "D",
+            u: "E",
+            v: "F",
         };
 
         // Do the conversion and return the 48 bit integer


### PR DESCRIPTION
There is not a hexidecimal digit 'G'.

Also please consider taking the changes from https://github.com/ramilexe/yubico-node